### PR TITLE
Fix package-file argument

### DIFF
--- a/Cask
+++ b/Cask
@@ -1,4 +1,4 @@
 (source gnu)
 (source melpa)
 
-(package-file "pangu-spacing")
+(package-file "pangu-spacing.el")


### PR DESCRIPTION
I got error when executing `cask`. The argument of `package-file` must be file path, not package name.

```
% cask
Opening input file: no such file or directory
```
