### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,11 +143,11 @@ Determine whether overlay OV was created by space-between.
 
 #### `(pangu-spacing-check-overlay)`
 
-Insert a space between English words and Chinese charactors in overlay.
+Insert a space between English words and Chinese characters in overlay.
 
 #### `(pangu-spacing-modify-buffer)`
 
-Real insert separator between English words and Chinese charactors in buffer.
+Real insert separator between English words and Chinese characters in buffer.
 
 #### `(pangu-spacing-region-has-pangu-spacing-overlays BEG END)`
 


### PR DESCRIPTION
@coldnew, I've corrected a typographical error in the documentation of the [pangu-spacing](https://github.com/coldnew/pangu-spacing) project. Specifically, I've changed charactor to character. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.