### PR TITLE
Performance

### DIFF
--- a/pangu-spacing.el
+++ b/pangu-spacing.el
@@ -177,24 +177,17 @@ When you set t here, the space will be insert when you save file."
 ;; Url: http://lists.gnu.org/archive/html/emacs-diffs/2014-01/msg00049.html
 
 (defvar pangu-spacing-chinese-before-english-regexp
-  (rx (group-n 1 (category chinse-two-byte))
+  (rx (group-n 1 (and (category chinese-two-byte)
+                      (not (any "。，！？；：「」（）、"))))
       (group-n 2 (in "a-zA-Z0-9")))
   "Regexp to find Chinese character before English character.")
 
 (defvar pangu-spacing-chinese-after-english-regexp
+
   (rx (group-n 1 (in "a-zA-Z0-9"))
-      (group-n 2 (category chinse-two-byte)))
+      (group-n 2 (and (category chinese-two-byte)
+                      (not (any "。，！？；：「」（）、")))))
   "Regexp to find Chinese character after English character.")
-
-(defvar pangu-spacing-chinese-before-english-regexp-exclude
-  (rx (group-n 1 (or (in "。，！？；：「」（）、")))
-      (group-n 2 (in "a-zA-Z0-9")))
-  "Excluded regexp to find Chinese character before English character.")
-
-(defvar pangu-spacing-chinese-after-english-regexp-exclude
-  (rx (group-n 1 (in "a-zA-Z0-9"))
-      (group-n 2 (or (in "。，！？；：「」（）、"))))
-  "Excluded regexp to find Chinese character after English character.")
 
 ;;;; Functions
 
@@ -228,13 +221,7 @@ pangu-sapce-mode."
                                 pangu-spacing-chinese-before-english-regexp)
 
   (pangu-spacing-search-overlay pangu-spacing-make-overlay
-                                pangu-spacing-chinese-after-english-regexp)
-
-  (pangu-spacing-search-overlay pangu-spacing-delete-overlay
-                                pangu-spacing-chinese-before-english-regexp-exclude)
-
-  (pangu-spacing-search-overlay pangu-spacing-delete-overlay
-                                pangu-spacing-chinese-after-english-regexp-exclude))
+                                pangu-spacing-chinese-after-english-regexp))
 
 (defun pangu-spacing-modify-buffer ()
   "Real insert separator between English words and Chinese charactors in buffer."
@@ -243,15 +230,7 @@ pangu-sapce-mode."
                                       pangu-spacing-chinese-before-english-regexp)
 
     (pangu-spacing-search-and-replace "\\1 \\2"
-                                      pangu-spacing-chinese-after-english-regexp)
-
-    (pangu-spacing-search-and-replace "\\1\\2"
-                                      (replace-regexp-in-string "\\\\)\\\\(" "\\\\) \\\\("
-                                                                pangu-spacing-chinese-before-english-regexp-exclude))
-
-    (pangu-spacing-search-and-replace "\\1\\2"
-                                      (replace-regexp-in-string "\\\\)\\\\(" "\\\\) \\\\("
-                                                                pangu-spacing-chinese-after-english-regexp-exclude)))
+                                      pangu-spacing-chinese-after-english-regexp))
   ;; nil must be returned to allow use in write file hooks
   nil)
 

--- a/pangu-spacing.el
+++ b/pangu-spacing.el
@@ -227,7 +227,8 @@ pangu-sapce-mode."
                                 pangu-spacing-make-overlay
                                 pangu-spacing-chinese-before-english-regexp)
 
-  (pangu-spacing-search-overlay pangu-spacing-make-overlay
+  (pangu-spacing-search-overlay beg end
+                                pangu-spacing-make-overlay
                                 pangu-spacing-chinese-after-english-regexp))
 
 (defun pangu-spacing-modify-buffer ()


### PR DESCRIPTION
This is patch for a major performance improvement. Performance for `pangu-spacing` has always been an issue, especially for large files. With this patch, I am able to open a 30MB file with `pangu-spacing-mode` on.

The main idea is to use the `(beg end)` provided by `jit-lock-mode`, and only update those regions. One issue with this patch is that if you delete everything after the last pangu spacing, this spacing will persist. This is probably because there is no overlay after the last pangu spacing, and `jit-lock-mode` does not report the change. I tried adding a dummy overlay at the end, but it does not seem to work.

Personally, I feel OK with this limitation (anyway, it is recommend to have a line break at the end of a text file), and a workaround may be beyond my reach. It would be great if you can help with this limitation.