### PR TITLE
Fix the case for alternating characters

### DIFF
--- a/pangu-spacing.el
+++ b/pangu-spacing.el
@@ -208,7 +208,8 @@ pangu-spacing-mode."
        (while (re-search-forward ,regexp end t)
          (when (and (match-beginning 1)
                     (match-beginning 2))
-           ,func)))))
+           ,func
+           (backward-char))))))
 
 (defmacro pangu-spacing-search-overlay (beg end func regexp)
   "Helper macro to search and update overlay according func and regexp for

--- a/test/pangu-spacing-test.el
+++ b/test/pangu-spacing-test.el
@@ -1,6 +1,5 @@
 ;;; pangu-spacing-test.el --- Tests for pangu-spacing
 
-;;; pangu-spacing-test.el ends here
 
 (ert-deftest pangu-spacing-test/modify ()
   "Test if modify works"
@@ -10,7 +9,15 @@
     (let ((pangu-spacing-real-insert-separtor t))
       (pangu-spacing-modify-buffer))
     (should (string-equal "跟 alex 解释 task 弹性的问题。a。" (buffer-string)))
-    ))
+    )
+  (with-temp-buffer
+    (pangu-spacing-mode 1)
+    (insert "2019年08月22日 星期四")
+    (let ((pangu-spacing-real-insert-separtor t))
+      (pangu-spacing-modify-buffer))
+    (should (string-equal "2019 年 08 月 22 日 星期四" (buffer-string)))
+    )
+  )
 
 (ert-deftest pangu-spacing-test/show ()
   "Test if showing works"
@@ -30,3 +37,4 @@
                 (insert " "))
               sorted-pos)
       (should (string-equal "跟 alex 解释 task 弹性的问题。a。" (buffer-string))))))
+;;; pangu-spacing-test.el ends here


### PR DESCRIPTION
For a string "2019年08月22日 星期四", if we write modification, it becomes "2019 年08 月 22日 星期四", since real modifying matches "9年", and "年" is not considered for future mappings. Therefore, there is problem if we have characters alternating between English and Chinese.