### PR TITLE
Support Japanese hiragana and katakana

### DIFF
--- a/pangu-spacing.el
+++ b/pangu-spacing.el
@@ -177,12 +177,17 @@ When you set t here, the space will be insert when you save file."
 ;; Url: http://lists.gnu.org/archive/html/emacs-diffs/2014-01/msg00049.html
 
 (defvar pangu-spacing-include-regexp
+  ;; we didn't add korean because korean-hangul-two-byte is not implemented
   (rx (or (and (or (group-n 3 (any "。，！？；：「」（）、"))
-                   (group-n 1 (category chinse-two-byte)))
+                   (group-n 1 (or (category chinse-two-byte)
+                                  (category japanese-hiragana-two-byte)
+                                  (category japanese-katakana-two-byte))))
                (group-n 2 (in "a-zA-Z0-9")))
           (and (group-n 1 (in "a-zA-Z0-9"))
                (or (group-n 3 (any "。，！？；：「」（）、"))
-                   (group-n 2 (category chinse-two-byte))))))
+                   (group-n 2 (or (category chinse-two-byte)
+                                  (category japanese-hiragana-two-byte)
+                                  (category japanese-katakana-two-byte)))))))
   "Regexp to find Chinese character before English character.
 
 Group 1 contains the character before the potential pangu

--- a/test/pangu-spacing-test.el
+++ b/test/pangu-spacing-test.el
@@ -37,4 +37,28 @@
                 (insert " "))
               sorted-pos)
       (should (string-equal "跟 alex 解释 task 弹性的问题。a。" (buffer-string))))))
+
+(ert-deftest pangu-spacing-test/japanese ()
+  "Test Japanese and Korean pangu-spacing"
+  (with-temp-buffer
+    (pangu-spacing-mode 1)
+    (insert "こんにちはhello worldこんにちは
+コンニチハhello worldコンニチハ")
+    (let ((pangu-spacing-real-insert-separtor t))
+      (pangu-spacing-modify-buffer))
+    ;; (pangu-spacing-check-overlay (point-min) (point-max))
+    ;; (let* ((overlay-list (overlays-in (point-min) (point-max)))
+    ;;        (overlay-pos (mapcar (lambda (ov)
+    ;;                               (when (pangu-spacing-overlay-p ov)
+    ;;                                 (overlay-end ov)))
+    ;;                             overlay-list))
+    ;;        (sorted-pos (sort overlay-pos '>=)))
+    ;;   (mapcar (lambda (pos)
+    ;;             (goto-char pos)
+    ;;             (insert " "))
+    ;;           sorted-pos)
+      (should (string-equal "こんにちは hello world こんにちは
+コンニチハ hello world コンニチハ" (buffer-string))))
+  )
+
 ;;; pangu-spacing-test.el ends here


### PR DESCRIPTION
Addressing #25 . Korean is not supported, since category =korean-hangul-two-byte= seems not implemented in emacs at all. 