### PR TITLE
Add `make test` command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,5 +15,7 @@ clean:
 %.elc: %.el
 	$(BATCH) --eval '(byte-compile-file "$<")'
 
+test:
+	$(BATCH) -L . -l test/pangu-spacing-test.el -f ert-run-tests-batch-and-exit
 
-.PHONY: check clean README.md
+.PHONY: check clean test README.md

--- a/test/pangu-spacing-test.el
+++ b/test/pangu-spacing-test.el
@@ -1,5 +1,7 @@
 ;;; pangu-spacing-test.el --- Tests for pangu-spacing
 
+(require 'ert)
+(require 'pangu-spacing)
 
 (ert-deftest pangu-spacing-test/modify ()
   "Test if modify works"


### PR DESCRIPTION
So we can use `make test` to run ert-test

$ make test

emacs  -batch -q -no-site-file -L . -L . -l test/pangu-spacing-test.el -f ert-run-tests-batch-and-exit
Running 2 tests (2019-08-23 11:12:31+0800, selector ‘t’)
   passed  1/2  pangu-spacing-test/modify (0.000271 sec)
   passed  2/2  pangu-spacing-test/show (0.000134 sec)

Ran 2 tests, 2 results as expected, 0 unexpected (2019-08-23 11:12:31+0800, 0.000654 sec)

Signed-off-by: Yen-Chin Lee <coldnew.tw@gmail.com>