### PR TITLE
Add tracis-ci support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ os:
   - osx
 
 env:
+  - EMACS_CI=emacs-24-2
+  - EMACS_CI=emacs-24-3
   - EMACS_CI=emacs-24-4
   - EMACS_CI=emacs-24-5
   - EMACS_CI=emacs-25-1

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: nix
 
 os:
   - linux
-  - osx
+#  - osx
 
 env:
   - EMACS_CI=emacs-24-2

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ os:
   - linux
   - osx
 
-before_install:
-  - export PATH="$HOME/.cask/bin:$PATH"
-  - curl -fsSkL https://raw.github.com/cask/cask/master/go | python
-
 env:
   - EMACS_CI=emacs-24-4
   - EMACS_CI=emacs-24-5
@@ -28,9 +24,11 @@ matrix:
   allow_failures:
     - env: EMACS_CI=emacs-snapshot
 
+# The default "emacs" executable on the $PATH will now be the version named by $EMACS_CI
 install:
-  # The default "emacs" executable on the $PATH will now be the version named by $EMACS_CI
   - bash <(curl https://raw.githubusercontent.com/purcell/nix-emacs-ci/master/travis-install)
+  - export PATH="$HOME/.cask/bin:$PATH"
+  - curl -fsSkL https://raw.github.com/cask/cask/master/go | python
 
 script:
   - emacs --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,12 @@ env:
   - EMACS_CI=emacs-26-3
   - EMACS_CI=emacs-snapshot
 
+# emacs-24-2 and emacs-24-3 may failure on test
+# just ignore it now.
 matrix:
   allow_failures:
+    - env: EMACS_CI=emacs-24-2
+    - env: EMACS_CI=emacs-24-3
     - env: EMACS_CI=emacs-snapshot
 
 # The default "emacs" executable on the $PATH will now be the version named by $EMACS_CI

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+language: ruby
+
+cache:
+  directories:
+    - $HOME/.evm
+
+before_install:
+  - (cd $HOME/.evm && git pull) || git clone https://github.com/rejeep/evm.git $HOME/.evm
+  - export PATH=$HOME/.evm/bin:$PATH
+  - evm config path /tmp
+  - evm install $EVM_EMACS --use --skip
+  - export PATH="$HOME/.cask/bin:$PATH"
+  - curl -fsSkL https://raw.github.com/cask/cask/master/go | python
+
+env:
+  - EVM_EMACS=emacs-24.1-travis
+  - EVM_EMACS=emacs-24.2-travis
+  - EVM_EMACS=emacs-24.3-travis
+  - EVM_EMACS=emacs-24.4-travis
+  - EVM_EMACS=emacs-24.5-travis
+  - EVM_EMACS=emacs-25.1-travis
+  - EVM_EMACS=emacs-25.2-travis
+  - EVM_EMACS=emacs-25.3-travis
+  - EVM_EMACS=emacs-26.1-travis
+  - EVM_EMACS=emacs-26.2-travis
+  - EVM_EMACS=emacs-git-snapshot-travis
+  - EVM_EMACS=remacs-git-snapshot-travis
+
+matrix:
+  allow_failures:
+    - env: EVM_EMACS=emacs-git-snapshot-travis
+    - env: EVM_EMACS=remacs-git-snapshot-travis
+
+script:
+  - emacs --version
+  - make clean
+  - make
+  - make test
+
+# Local Variables:
+# indent-tabs-mode: nil
+# coding: utf-8
+# End:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,36 @@
-language: ruby
+#
+# Use nix-emacs-ci for travis CI
+# URL: https://github.com/purcell/nix-emacs-ci
+#
 
-cache:
-  directories:
-    - $HOME/.evm
+language: nix
+
+os:
+  - linux
+  - osx
 
 before_install:
-  - (cd $HOME/.evm && git pull) || git clone https://github.com/rejeep/evm.git $HOME/.evm
-  - export PATH=$HOME/.evm/bin:$PATH
-  - evm config path /tmp
-  - evm install $EVM_EMACS --use --skip
   - export PATH="$HOME/.cask/bin:$PATH"
   - curl -fsSkL https://raw.github.com/cask/cask/master/go | python
 
 env:
-  - EVM_EMACS=emacs-24.1-travis
-  - EVM_EMACS=emacs-24.2-travis
-  - EVM_EMACS=emacs-24.3-travis
-  - EVM_EMACS=emacs-24.4-travis
-  - EVM_EMACS=emacs-24.5-travis
-  - EVM_EMACS=emacs-25.1-travis
-  - EVM_EMACS=emacs-25.2-travis
-  - EVM_EMACS=emacs-25.3-travis
-  - EVM_EMACS=emacs-26.1-travis
-  - EVM_EMACS=emacs-26.2-travis
-  - EVM_EMACS=emacs-git-snapshot-travis
-  - EVM_EMACS=remacs-git-snapshot-travis
+  - EMACS_CI=emacs-24-4
+  - EMACS_CI=emacs-24-5
+  - EMACS_CI=emacs-25-1
+  - EMACS_CI=emacs-25-2
+  - EMACS_CI=emacs-25-3
+  - EMACS_CI=emacs-26-1
+  - EMACS_CI=emacs-26-2
+  - EMACS_CI=emacs-26-3
+  - EMACS_CI=emacs-snapshot
 
 matrix:
   allow_failures:
-    - env: EVM_EMACS=emacs-git-snapshot-travis
-    - env: EVM_EMACS=remacs-git-snapshot-travis
+    - env: EMACS_CI=emacs-snapshot
+
+install:
+  # The default "emacs" executable on the $PATH will now be the version named by $EMACS_CI
+  - bash <(curl https://raw.githubusercontent.com/purcell/nix-emacs-ci/master/travis-install)
 
 script:
   - emacs --version


### PR DESCRIPTION
pangu-spacing can work on emacs 24.1 or above, add travis-ci to help us verify every PRs worked fine.

Note:
Currently the emacs-24-2 and emacs-24-3 my build failed on travis-ci, just ignore the error.
